### PR TITLE
[fix] Change parameter for blacklisted_az

### DIFF
--- a/cdn/module.tf
+++ b/cdn/module.tf
@@ -8,7 +8,7 @@ provider "aws" {
 
 data "aws_availability_zones" "available" {
   state             = "available"
-  blacklisted_names = var.blacklisted_az
+  exclude_names     = var.blacklisted_az
 }
 
 data "aws_route53_zone" "default" {


### PR DESCRIPTION
According to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones#exclude_names the parameter name must be exclude_names instead of blacklisted_az.

I received an error with blacklisted_az:

Error: Unsupported argument

  on cdn/module.tf line 11, in data "aws_availability_zones" "available":
  11:   blacklisted_az     = var.blacklisted_az

An argument named "blacklisted_az" is not expected here.